### PR TITLE
feat: add hover descriptions for software libraries

### DIFF
--- a/src/components/workflowMenu.jsx
+++ b/src/components/workflowMenu.jsx
@@ -6,6 +6,7 @@ import {
     toolsByModality,
     modalityOrder,
     modalityDescriptions,
+    libraryDescriptions,
     libraryOrder,
     dummyNodes,
 } from '../utils/toolAnnotations';
@@ -646,14 +647,21 @@ function WorkflowMenu({ onEditWorkflow, onDeleteWorkflow }) {
 
                                                     return (
                                                         <div key={libraryKey} className="library-section">
-                                                            <div
-                                                                className="library-header"
-                                                                onClick={() => toggleSection(libraryKey)}
+                                                            <ModalityTooltip
+                                                                name={library}
+                                                                description={libraryDescriptions[library]}
                                                             >
-                                                                <Chevron expanded={isLibraryExpanded} />
-                                                                <span className="library-name">{library}</span>
-                                                                <span className="tool-count">{libraryToolCount}</span>
-                                                            </div>
+                                                                <div
+                                                                    className="library-header"
+                                                                    onClick={() => toggleSection(libraryKey)}
+                                                                >
+                                                                    <Chevron expanded={isLibraryExpanded} />
+                                                                    <span className="library-name">{library}</span>
+                                                                    <span className="tool-count">
+                                                                        {libraryToolCount}
+                                                                    </span>
+                                                                </div>
+                                                            </ModalityTooltip>
 
                                                             {isLibraryExpanded && (
                                                                 <div className="library-tools">

--- a/src/utils/toolAnnotations.js
+++ b/src/utils/toolAnnotations.js
@@ -3596,6 +3596,31 @@ export const modalityDescriptions = {
         'Complete multi-step analysis pipelines that chain several operations internally. Each tool orchestrates preprocessing, registration, segmentation, or analysis stages as a single command.',
 };
 
+/**
+ * One-line descriptions for the software libraries shown as the middle tier of
+ * the tool menu (modality → library → category). Surfaced on hover, mirroring
+ * `modalityDescriptions`. Keys must match the library names in `libraryOrder`.
+ */
+export const libraryDescriptions = {
+    FSL: "FMRIB Software Library — Oxford's comprehensive toolset for structural, functional, and diffusion MRI: brain extraction, registration, segmentation, and GLM analysis.",
+    AFNI: 'Analysis of Functional NeuroImages — NIMH suite focused on functional MRI processing, statistics, and visualization.',
+    SPM: 'Statistical Parametric Mapping — MATLAB-based package for the analysis of brain imaging data sequences.',
+    FreeSurfer:
+        'Surface-based analysis suite for cortical reconstruction, parcellation, and morphometry from structural MRI.',
+    ANTs: 'Advanced Normalization Tools — state-of-the-art image registration, segmentation, and template construction.',
+    MRtrix3:
+        'Diffusion MRI toolkit for fiber orientation estimation, tractography, and structural connectivity.',
+    fMRIPrep:
+        'Robust, automated preprocessing pipeline for task-based and resting-state fMRI, combining tools across libraries.',
+    MRIQC: 'Automated extraction of image quality metrics for structural and functional MRI.',
+    'Connectome Workbench':
+        'HCP visualization and analysis suite for surface- and volume-based connectome data (CIFTI).',
+    AMICO: 'Accelerated Microstructure Imaging via Convex Optimization — fast fitting of advanced diffusion models (e.g. NODDI).',
+    dcm2niix: 'Converts DICOM and PAR/REC imaging data into the NIfTI format, with BIDS-compatible sidecars.',
+    'ICA-AROMA':
+        'ICA-based Automatic Removal Of Motion Artifacts — data-driven denoising of motion-related signal in fMRI.',
+};
+
 /** Parameters whose CLI position is fixed and should not be reordered by operation-order. */
 export const FIXED_POSITION_PARAMS = new Set(['input', 'output', 'odt', 'kernel_size']);
 


### PR DESCRIPTION
## Summary

Adds hover descriptions to the software-library headers (FSL, AFNI, FreeSurfer,
ANTs, and others) in the Tools tree, matching the existing tooltips for
modalities and individual tools. Reuses the existing tooltip component.

## Demo

**Before**

<!-- drag before.mp4 here -->

**After**

<!-- drag after.mp4 here -->

## Changes

- `src/utils/toolAnnotations.js` — `libraryDescriptions` map, one line per library.
- `src/components/workflowMenu.jsx` — wrap each library header in `ModalityTooltip`.

## Testing

- [ ] Hover a library header — the correct description appears.
- [ ] Modality and tool tooltips still render unchanged.
- [ ] A library with no description entry shows no tooltip and no error.
