### PR TITLE
feat: navigable canvas minimap and CWL/YML preview minimaps

### DIFF
--- a/src/components/CWLPreviewContent.jsx
+++ b/src/components/CWLPreviewContent.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import YAML from 'js-yaml';
 import { buildCWLWorkflowObject, buildJobTemplate } from '../hooks/buildWorkflow.js';
 import { useToast } from '../context/ToastContext.jsx';
+import MiniScrollMap from './MiniScrollMap.jsx';
 
 const SHEBANG = '#!/usr/bin/env cwl-runner\n\n';
 
@@ -49,6 +50,8 @@ function CWLPreviewContent({ getWorkflowData, pane = 'workflow', mode = 'panel' 
     const [copied, setCopied] = useState(false);
     const debounceRef = useRef(null);
     const copiedTimerRef = useRef(null);
+    // The scroll container — shared with the minimap so it can read/write scrollTop.
+    const scrollRef = useRef(null);
 
     useEffect(() => {
         if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -118,34 +121,37 @@ function CWLPreviewContent({ getWorkflowData, pane = 'workflow', mode = 'panel' 
     const containerClass = `cwl-preview-content${mode === 'tab' ? ' cwl-preview-content--tab' : ''}`;
 
     return (
-        <div className={containerClass}>
-            {error && (
-                <div className="cwl-error-banner">
-                    <span className="cwl-error-icon">!</span>
-                    <span>{error}</span>
-                </div>
-            )}
-            {showPlaceholder && !error && (
-                <div className="cwl-empty-message">Add a node to preview the generated CWL workflow.</div>
-            )}
-            {activeContent && (
-                <>
-                    <button
-                        className="cwl-content-copy-btn"
-                        onClick={handleCopy}
-                        disabled={!activeContent}
-                        title="Copy to clipboard"
-                    >
-                        {copied ? 'Copied!' : 'Copy'}
-                    </button>
-                    <div className="cwl-code-block">
-                        <pre className="cwl-line-gutter" aria-hidden="true">
-                            {lineNumbers}
-                        </pre>
-                        <pre className="cwl-code" dangerouslySetInnerHTML={{ __html: highlightedHtml }} />
+        <div className={`cwl-preview-host${mode === 'tab' ? ' cwl-preview-host--tab' : ''}`}>
+            <div className={containerClass} ref={scrollRef}>
+                {error && (
+                    <div className="cwl-error-banner">
+                        <span className="cwl-error-icon">!</span>
+                        <span>{error}</span>
                     </div>
-                </>
-            )}
+                )}
+                {showPlaceholder && !error && (
+                    <div className="cwl-empty-message">Add a node to preview the generated CWL workflow.</div>
+                )}
+                {activeContent && (
+                    <>
+                        <button
+                            className="cwl-content-copy-btn"
+                            onClick={handleCopy}
+                            disabled={!activeContent}
+                            title="Copy to clipboard"
+                        >
+                            {copied ? 'Copied!' : 'Copy'}
+                        </button>
+                        <div className="cwl-code-block">
+                            <pre className="cwl-line-gutter" aria-hidden="true">
+                                {lineNumbers}
+                            </pre>
+                            <pre className="cwl-code" dangerouslySetInnerHTML={{ __html: highlightedHtml }} />
+                        </div>
+                    </>
+                )}
+            </div>
+            {activeContent && !error && <MiniScrollMap html={highlightedHtml} scrollRef={scrollRef} />}
         </div>
     );
 }

--- a/src/components/MiniScrollMap.jsx
+++ b/src/components/MiniScrollMap.jsx
@@ -1,0 +1,109 @@
+import { useRef, useState, useEffect, useCallback } from 'react';
+
+/**
+ * VS Code–style minimap for the CWL/YML preview. A narrow gutter showing a
+ * scaled, non-interactive clone of the highlighted code as a texture, plus a
+ * draggable viewport indicator. Lightweight on purpose — no editor library; it
+ * just reads/writes the host scroll container's `scrollTop`.
+ *
+ * The code clone is decorative; navigation correctness comes entirely from the
+ * thumb, whose position/size derive from the scroller's scroll metrics. The
+ * clone is uniformly scaled so the whole document maps to the gutter height.
+ *
+ * @param {string} html - The same highlighted HTML rendered in the code pane.
+ * @param {{current: HTMLElement|null}} scrollRef - Ref to the scroll container.
+ */
+function MiniScrollMap({ html, scrollRef }) {
+    const mapRef = useRef(null);
+    const codeRef = useRef(null);
+    const draggingRef = useRef(false);
+    const [thumb, setThumb] = useState({ top: 0, height: 0, show: false });
+    const [scale, setScale] = useState(1);
+
+    const measure = useCallback(() => {
+        const sc = scrollRef.current;
+        const map = mapRef.current;
+        const code = codeRef.current;
+        if (!sc || !map) return;
+        const { scrollTop, scrollHeight, clientHeight } = sc;
+        const mapH = map.clientHeight;
+        // Fit the whole document into the gutter height (uniform, capped at 1:1).
+        if (code) {
+            const natural = code.scrollHeight || 1;
+            setScale(Math.min(1, mapH / natural));
+        }
+        if (scrollHeight <= clientHeight + 1) {
+            // Nothing to scroll — hide the thumb.
+            setThumb((t) => (t.show ? { ...t, show: false } : t));
+            return;
+        }
+        const height = Math.max(18, (clientHeight / scrollHeight) * mapH);
+        const top = (scrollTop / (scrollHeight - clientHeight)) * (mapH - height);
+        setThumb({ top, height, show: true });
+    }, [scrollRef]);
+
+    useEffect(() => {
+        const sc = scrollRef.current;
+        if (!sc) return;
+        measure();
+        sc.addEventListener('scroll', measure, { passive: true });
+        const ro = new ResizeObserver(measure);
+        ro.observe(sc);
+        return () => {
+            sc.removeEventListener('scroll', measure);
+            ro.disconnect();
+        };
+    }, [scrollRef, measure, html]);
+
+    // Center the viewport on the clicked/dragged position in the gutter.
+    const scrollToClientY = useCallback(
+        (clientY) => {
+            const sc = scrollRef.current;
+            const map = mapRef.current;
+            if (!sc || !map) return;
+            const rect = map.getBoundingClientRect();
+            const ratio = Math.min(1, Math.max(0, (clientY - rect.top) / rect.height));
+            const target = ratio * sc.scrollHeight - sc.clientHeight / 2;
+            sc.scrollTop = Math.min(sc.scrollHeight - sc.clientHeight, Math.max(0, target));
+        },
+        [scrollRef],
+    );
+
+    const onMouseDown = useCallback(
+        (e) => {
+            draggingRef.current = true;
+            scrollToClientY(e.clientY);
+            e.preventDefault();
+        },
+        [scrollToClientY],
+    );
+
+    useEffect(() => {
+        const move = (e) => {
+            if (draggingRef.current) scrollToClientY(e.clientY);
+        };
+        const up = () => {
+            draggingRef.current = false;
+        };
+        window.addEventListener('mousemove', move);
+        window.addEventListener('mouseup', up);
+        return () => {
+            window.removeEventListener('mousemove', move);
+            window.removeEventListener('mouseup', up);
+        };
+    }, [scrollToClientY]);
+
+    return (
+        <div className="cwl-minimap" ref={mapRef} onMouseDown={onMouseDown} aria-hidden="true">
+            <div
+                className="cwl-minimap-code"
+                ref={codeRef}
+                style={{ transform: `scale(${scale})` }}
+                dangerouslySetInnerHTML={{ __html: html }}
+            />
+            {thumb.show && <div className="cwl-minimap-thumb" style={{ top: thumb.top, height: thumb.height }} />}
+        </div>
+    );
+}
+
+export default MiniScrollMap;

--- a/src/components/workflowCanvas.jsx
+++ b/src/components/workflowCanvas.jsx
@@ -668,6 +668,8 @@ function WorkflowCanvas({
                                 }}
                             >
                                 <MiniMap
+                                    pannable
+                                    zoomable
                                     nodeColor="var(--color-accent)"
                                     maskColor="var(--minimap-mask)"
                                     style={{ backgroundColor: 'var(--minimap-bg)' }}

--- a/src/styles/cwlPreviewPanel.css
+++ b/src/styles/cwlPreviewPanel.css
@@ -171,12 +171,63 @@
 /* CWLPreviewContent: shared body used in both right-panel and aux-tab modes.
    Owns the scroll context (both axes) so .cwl-code-block can stretch wider
    than the container and the sticky line gutter stays anchored on the left. */
-.cwl-preview-content {
-    position: relative;
+/* Flex host: the scrolling code pane on the left, the minimap gutter on the
+   right. Fills whatever the panel/tab body gives it. */
+.cwl-preview-host {
+    display: flex;
     width: 100%;
     height: 100%;
     min-height: 0;
+    position: relative;
+}
+
+.cwl-preview-content {
+    position: relative;
+    flex: 1 1 auto;
+    min-width: 0;
+    height: 100%;
+    min-height: 0;
     overflow: auto;
+}
+
+/* ── Editor minimap gutter ───────────────────────────────────────────────── */
+.cwl-minimap {
+    position: relative;
+    flex-shrink: 0;
+    width: 64px;
+    height: 100%;
+    overflow: hidden;
+    cursor: pointer;
+    background-color: var(--bg-elevated);
+    border-left: 1px solid var(--border-subtle);
+    user-select: none;
+}
+
+/* Decorative scaled clone of the code — a texture, not interactive. */
+.cwl-minimap-code {
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform-origin: top left;
+    margin: 0;
+    padding: 4px 6px;
+    font-family: var(--font-mono);
+    font-size: 2px;
+    line-height: 3px;
+    white-space: pre;
+    color: var(--text-muted);
+    pointer-events: none;
+}
+
+/* Viewport indicator — drag it to scroll the code pane. */
+.cwl-minimap-thumb {
+    position: absolute;
+    left: 0;
+    right: 0;
+    background-color: var(--color-accent-muted);
+    border-top: 1px solid var(--color-accent-border);
+    border-bottom: 1px solid var(--color-accent-border);
+    pointer-events: none;
 }
 
 /* Tab variant: edge-to-edge fill of the canvas-wrapper. Only differences from


### PR DESCRIPTION
## Summary

Makes the canvas minimap navigable (drag or click to move the viewport) and adds
a matching minimap to the CWL and YML preview panes, so both surfaces share the
same overview-and-navigate behavior.

## Demo

**Before**

<!-- drag before.mp4 here -->

**After**

<!-- drag after.mp4 here -->

## Changes

- `src/components/workflowCanvas.jsx` — enable `pannable`/`zoomable` on the canvas minimap.
- `src/components/MiniScrollMap.jsx` — minimap for the preview panes (scaled code clone + draggable indicator).
- `src/components/CWLPreviewContent.jsx` — flex host wrapping the scroll pane and the minimap.
- `src/styles/cwlPreviewPanel.css` — host and minimap styling.

## Testing

- [ ] Drag the canvas minimap — the viewport follows; scroll over it — it zooms.
- [ ] Open a long workflow — the preview minimap shows a full-document overview.
- [ ] Drag the preview indicator — the pane scrolls; scrolling the pane moves the indicator.
- [ ] Switch between the .cwl and .yml panes — the minimap updates.
