### PR TITLE
feat: disambiguate/link top-bar tabs and add tab-strip scrolling

### DIFF
--- a/src/components/IDELayout.jsx
+++ b/src/components/IDELayout.jsx
@@ -7,6 +7,7 @@ import SidebarBidsContent from './SidebarBidsContent.jsx';
 import SidebarStagedChangesContent from './SidebarStagedChangesContent.jsx';
 import { useToast } from '../context/ToastContext.jsx';
 import { useSidebar } from '../context/SidebarContext.jsx';
+import { dedupeLabels } from '../utils/dedupeLabels.js';
 import '../styles/ideLayout.css';
 
 function IDELayout({
@@ -112,6 +113,15 @@ function IDELayout({
     // cwl/yml tabs already embed the workspace name in their base label and are
     // pass-through. Computed once per render to avoid O(n²) lookups in the tab
     // strip walk below.
+    // Workspace tab titles, with duplicate names disambiguated as "name (1)",
+    // "name (2)" — same numbering the canvas uses for duplicate nodes. Keyed by
+    // workspace id so it's stable as workspaces are added/renamed. Empty names
+    // fall back to the positional "Workspace N" (already unique).
+    const workspaceLabelMap = useMemo(
+        () => dedupeLabels(workspaces.map((w, i) => ({ id: w.id, label: w.name?.trim() || `Workspace ${i + 1}` }))),
+        [workspaces],
+    );
+
     const auxLabelMap = useMemo(() => {
         const wsById = new Map(workspaces.map((w) => [w.id, w]));
         const info = new Map(); // auxId -> { base, wsLabel, collides }
@@ -120,7 +130,9 @@ function IDELayout({
         for (const t of auxTabs) {
             const ws = wsById.get(t.workspaceId);
             if (!ws) continue;
-            const wsLabel = ws.name || 'workspace';
+            // Use the disambiguated workspace title so a CWL/YML tab traces back
+            // unambiguously to its source workspace even when names collide.
+            const wsLabel = workspaceLabelMap.get(t.workspaceId) || ws.name || 'workspace';
             let base;
             let collides = false;
             if (t.type === 'cwl') {
@@ -146,7 +158,7 @@ function IDELayout({
             out.set(id, collide ? `${v.wsLabel}/${v.base}` : v.base);
         }
         return out;
-    }, [auxTabs, workspaces]);
+    }, [auxTabs, workspaces, workspaceLabelMap]);
 
     // Per-workspace decoration kind for the tab strip:
     //   'workflow'    → WRKF (blue)
@@ -675,7 +687,9 @@ function IDELayout({
                                                                     ) : (
                                                                         <>
                                                                             <span className="ide-tab-label">
-                                                                                {ws.name || `Workspace ${i + 1}`}
+                                                                                {workspaceLabelMap.get(ws.id) ||
+                                                                                    ws.name ||
+                                                                                    `Workspace ${i + 1}`}
                                                                             </span>
                                                                             {status && (
                                                                                 <span className="ide-tab-badge">

--- a/src/components/IDELayout.jsx
+++ b/src/components/IDELayout.jsx
@@ -86,6 +86,66 @@ function IDELayout({
     // 2px drop indicator should render.
     const [dropTarget, setDropTarget] = useState(null);
 
+    // Horizontal scrolling for the tab strip — vertical wheel is mapped onto
+    // horizontal scroll, and edge buttons appear when the tabs overflow. This
+    // operates on the scroll container itself, so it is independent of how the
+    // tabs are ordered and composes with the grouped-tabs view.
+    const tabsScrollRef = useRef(null);
+    const [tabOverflow, setTabOverflow] = useState({ left: false, right: false });
+
+    const updateTabOverflow = useCallback(() => {
+        const el = tabsScrollRef.current;
+        if (!el) return;
+        const maxScroll = el.scrollWidth - el.clientWidth;
+        const left = el.scrollLeft > 1;
+        const right = el.scrollLeft < maxScroll - 1;
+        setTabOverflow((prev) => (prev.left === left && prev.right === right ? prev : { left, right }));
+    }, []);
+
+    const scrollTabsBy = useCallback((direction) => {
+        const el = tabsScrollRef.current;
+        if (!el) return;
+        el.scrollBy({ left: direction * Math.max(160, el.clientWidth * 0.7), behavior: 'smooth' });
+    }, []);
+
+    // Map a vertical mouse wheel onto horizontal scroll. Attached natively as a
+    // non-passive listener because React's synthetic onWheel is passive, so
+    // preventDefault would otherwise be ignored. Trackpad horizontal gestures
+    // fall through to the browser's native handling.
+    useEffect(() => {
+        const el = tabsScrollRef.current;
+        if (!el) return;
+        const onWheel = (e) => {
+            if (el.scrollWidth <= el.clientWidth) return;
+            if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+                el.scrollLeft += e.deltaY;
+                e.preventDefault();
+            }
+        };
+        el.addEventListener('wheel', onWheel, { passive: false });
+        return () => el.removeEventListener('wheel', onWheel);
+    }, []);
+
+    // Keep the edge-button visibility in sync with scroll position and size.
+    useEffect(() => {
+        const el = tabsScrollRef.current;
+        if (!el) return;
+        updateTabOverflow();
+        el.addEventListener('scroll', updateTabOverflow, { passive: true });
+        const ro = new ResizeObserver(updateTabOverflow);
+        ro.observe(el);
+        return () => {
+            el.removeEventListener('scroll', updateTabOverflow);
+            ro.disconnect();
+        };
+    }, [updateTabOverflow]);
+
+    // Recompute when the set of tabs changes — content width can change without
+    // the container resizing.
+    useEffect(() => {
+        updateTabOverflow();
+    }, [tabOrder, auxTabs, workspaces, updateTabOverflow]);
+
     // Derive view modes from activeTabKey (single source of truth).
     const isManagerActive = activeTabKey === 'manager';
     const isAuxActive = typeof activeTabKey === 'string' && activeTabKey.startsWith('aux-');
@@ -581,7 +641,34 @@ function IDELayout({
                                     <Panel id="center">
                                         <div className="ide-center-column">
                                             <div className="ide-tab-bar">
-                                                <div className="ide-tabs-scroll" onDragOver={handleScrollAreaDragOver}>
+                                                {tabOverflow.left && (
+                                                    <button
+                                                        type="button"
+                                                        className="ide-tab-scroll-btn ide-tab-scroll-left"
+                                                        onClick={() => scrollTabsBy(-1)}
+                                                        title="Scroll tabs left"
+                                                        aria-label="Scroll tabs left"
+                                                    >
+                                                        <svg
+                                                            width="14"
+                                                            height="14"
+                                                            viewBox="0 0 24 24"
+                                                            fill="none"
+                                                            stroke="currentColor"
+                                                            strokeWidth="2"
+                                                            strokeLinecap="round"
+                                                            strokeLinejoin="round"
+                                                            aria-hidden="true"
+                                                        >
+                                                            <polyline points="15 18 9 12 15 6" />
+                                                        </svg>
+                                                    </button>
+                                                )}
+                                                <div
+                                                    className="ide-tabs-scroll"
+                                                    ref={tabsScrollRef}
+                                                    onDragOver={handleScrollAreaDragOver}
+                                                >
                                                     {/* Permanent Workflow Manager tab — non-closeable, leftmost.
                                                         Intentionally lacks drag handlers: it's pinned and never
                                                         reorderable, and never a drop target. */}
@@ -785,6 +872,29 @@ function IDELayout({
                                                         return null;
                                                     })}
                                                 </div>
+                                                {tabOverflow.right && (
+                                                    <button
+                                                        type="button"
+                                                        className="ide-tab-scroll-btn ide-tab-scroll-right"
+                                                        onClick={() => scrollTabsBy(1)}
+                                                        title="Scroll tabs right"
+                                                        aria-label="Scroll tabs right"
+                                                    >
+                                                        <svg
+                                                            width="14"
+                                                            height="14"
+                                                            viewBox="0 0 24 24"
+                                                            fill="none"
+                                                            stroke="currentColor"
+                                                            strokeWidth="2"
+                                                            strokeLinecap="round"
+                                                            strokeLinejoin="round"
+                                                            aria-hidden="true"
+                                                        >
+                                                            <polyline points="9 18 15 12 9 6" />
+                                                        </svg>
+                                                    </button>
+                                                )}
                                                 <button
                                                     className="ide-tab-add"
                                                     onClick={() => onNewWorkspace()}

--- a/src/components/workflowCanvas.jsx
+++ b/src/components/workflowCanvas.jsx
@@ -22,6 +22,7 @@ import { useSidebar } from '../context/SidebarContext.jsx';
 import { useCustomWorkflowsContext } from '../context/CustomWorkflowsContext.jsx';
 import { useToast } from '../context/ToastContext.jsx';
 import { layoutGraph } from '../utils/layoutGraph.js';
+import { dedupeLabels } from '../utils/dedupeLabels.js';
 
 // Define node types.
 const nodeTypes = { default: NodeComponent };
@@ -84,25 +85,12 @@ function WorkflowCanvas({
         if (labelKey === prevLabelKeyRef.current) return;
         prevLabelKeyRef.current = labelKey;
 
-        // Count occurrences of each label
-        const labelCounts = {};
-        for (const n of nodes) {
-            const label = n.data?.label || '';
-            labelCounts[label] = (labelCounts[label] || 0) + 1;
-        }
-
-        // Assign display labels only for duplicates
-        const labelSeq = {};
+        // Number duplicate labels (e.g. "flirt (1)", "flirt (2)") via the shared
+        // dedupe util — the same numbering the top-bar tabs use.
+        const displayMap = dedupeLabels(nodes.map((n) => ({ id: n.id, label: n.data?.label || '' })));
         let anyChange = false;
         const updated = nodes.map((n) => {
-            const label = n.data?.label || '';
-            let displayLabel;
-            if (labelCounts[label] > 1) {
-                labelSeq[label] = (labelSeq[label] || 0) + 1;
-                displayLabel = `${label} (${labelSeq[label]})`;
-            } else {
-                displayLabel = label;
-            }
+            const displayLabel = displayMap.get(n.id);
             if (n.data?.displayLabel !== displayLabel) {
                 anyChange = true;
                 return { ...n, data: { ...n.data, displayLabel } };

--- a/src/styles/ideLayout.css
+++ b/src/styles/ideLayout.css
@@ -345,6 +345,41 @@
     box-shadow: none;
 }
 
+/* Tab-strip scroll buttons — shown at the edges of the bar only when the tabs
+   overflow. Full-height hit targets that read as fixed bar chrome beside the
+   scrolling strip. */
+.ide-tab-scroll-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 100%;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    flex-shrink: 0;
+    transition:
+        background-color var(--transition-fast),
+        color var(--transition-fast);
+}
+
+.ide-tab-scroll-btn:hover {
+    background-color: var(--bg-hover);
+    color: var(--text-primary);
+    transform: none;
+    box-shadow: none;
+}
+
+.ide-tab-scroll-left {
+    border-right: 1px solid var(--border-default);
+}
+
+.ide-tab-scroll-right {
+    border-left: 1px solid var(--border-default);
+}
+
 .ide-tab-dirty {
     color: var(--color-warning);
 }

--- a/src/utils/dedupeLabels.js
+++ b/src/utils/dedupeLabels.js
@@ -1,0 +1,34 @@
+/**
+ * Disambiguate duplicate labels by appending " (n)" suffixes.
+ *
+ * Given an ordered list of `{ id, label }`, returns a `Map<id, displayLabel>`.
+ * A label that appears once is passed through untouched. When a label appears
+ * more than once, EVERY occurrence is numbered with a 1-based ordinal in input
+ * order — `flirt (1)`, `flirt (2)`, `flirt (3)`. Order in is order out, so the
+ * numbering is stable as long as the input order is.
+ *
+ * Single source of truth for the duplicate-numbering used by both canvas node
+ * display labels and the top-bar workspace/aux tab labels.
+ *
+ * @param {Array<{id: string, label: string}>} items
+ * @returns {Map<string, string>}
+ */
+export function dedupeLabels(items) {
+    const counts = new Map();
+    for (const { label } of items) {
+        counts.set(label, (counts.get(label) || 0) + 1);
+    }
+
+    const seq = new Map();
+    const out = new Map();
+    for (const { id, label } of items) {
+        if ((counts.get(label) || 0) > 1) {
+            const n = (seq.get(label) || 0) + 1;
+            seq.set(label, n);
+            out.set(id, `${label} (${n})`);
+        } else {
+            out.set(id, label);
+        }
+    }
+    return out;
+}


### PR DESCRIPTION
## Summary

Disambiguates duplicate workspace/tab names, links each CWL/YML preview tab to
its source workspace, and lets the tab strip scroll by mouse wheel or by edge
buttons when the tabs overflow.

## Demo

**Before**

<!-- drag before.mp4 here -->

**After**

<!-- drag after.mp4 here -->

## Changes

- `src/utils/dedupeLabels.js` — shared duplicate-numbering helper.
- `src/components/workflowCanvas.jsx` — node display labels use the helper (no behavior change).
- `src/components/IDELayout.jsx` — number duplicate tab titles; prefix CWL/YML tabs with the workspace name; map vertical wheel to horizontal scroll and add edge scroll buttons.
- `src/styles/ideLayout.css` — scroll-button styling.

## Testing

- [ ] Two workspaces with the same name → tabs read `name (1)` / `name (2)`.
- [ ] Each workspace's CWL/YML tab carries the matching workspace prefix.
- [ ] With the bar overflowing, a mouse wheel scrolls the strip; the edge buttons appear and scroll it.
- [ ] Two identically-named nodes still label `(1)` / `(2)` on the canvas.

---

Merge before **group-tabs-by-workflow** (both touch `IDELayout.jsx`; the scroll
logic is order-independent, so the two compose).
