### PR TITLE
feat: add light/dark theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
     <title>niBuild</title>
+    <script>
+      // Resolve the theme before first paint to avoid a flash. A persisted choice
+      // wins; otherwise follow the OS preference. The TopBar toggle keeps this
+      // attribute and localStorage in sync.
+      (function () {
+        try {
+          var t = localStorage.getItem('theme');
+          if (t !== 'light' && t !== 'dark') {
+            t = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+          }
+          document.documentElement.setAttribute('data-theme', t);
+        } catch (e) {
+          document.documentElement.setAttribute('data-theme', 'dark');
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,0 +1,82 @@
+import { useState, useCallback } from 'react';
+
+// Read the theme that the no-flash inline script (index.html) already applied
+// to <html>. Falls back to 'dark' if the attribute is missing.
+function getInitialTheme() {
+    if (typeof document !== 'undefined') {
+        const cur = document.documentElement.getAttribute('data-theme');
+        if (cur === 'light' || cur === 'dark') return cur;
+    }
+    return 'dark';
+}
+
+/**
+ * Light/dark theme toggle. Self-contained: it flips the `data-theme` attribute
+ * on <html> (which swaps the CSS custom properties in tokens.css) and persists
+ * the choice to localStorage. No context needed — nothing else consumes the
+ * theme, and the initial value is established before paint in index.html.
+ */
+function ThemeToggle() {
+    const [theme, setTheme] = useState(getInitialTheme);
+
+    const toggle = useCallback(() => {
+        setTheme((prev) => {
+            const next = prev === 'dark' ? 'light' : 'dark';
+            document.documentElement.setAttribute('data-theme', next);
+            try {
+                localStorage.setItem('theme', next);
+            } catch {
+                /* localStorage unavailable — the runtime toggle still applies */
+            }
+            return next;
+        });
+    }, []);
+
+    const isDark = theme === 'dark';
+    const label = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+
+    return (
+        <button
+            type="button"
+            className="top-bar-btn top-bar-theme-toggle"
+            onClick={toggle}
+            title={label}
+            aria-label={label}
+        >
+            {isDark ? (
+                // Sun — clicking switches to light.
+                <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                >
+                    <circle cx="12" cy="12" r="4" />
+                    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+                </svg>
+            ) : (
+                // Moon — clicking switches to dark.
+                <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                >
+                    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+                </svg>
+            )}
+        </button>
+    );
+}
+
+export default ThemeToggle;

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import ThemeToggle from './ThemeToggle';
 import '../styles/topBar.css';
 
 /**
@@ -143,6 +144,7 @@ function TopBar({
             </div>
 
             <div className="top-bar-right">
+                <ThemeToggle />
                 <button
                     className="top-bar-btn top-bar-btn-action top-bar-btn-save-workflow"
                     onClick={onSaveAsWorkflow}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -192,6 +192,108 @@
     --minimap-mask: rgba(0, 0, 0, 0.65);
 }
 
+/* ============================================================
+   Light theme — overrides only the color/surface tokens; typography,
+   spacing, radius and transitions are theme-agnostic and stay in :root.
+   Activated by `data-theme="light"` on <html>, set by the no-flash inline
+   script in index.html and toggled by the TopBar theme button. Every
+   component already reads these via var(), so no per-component CSS changes
+   are needed. (VS Code "Light Modern" palette.)
+   ============================================================ */
+:root[data-theme='light'] {
+    /* ── Background: Core surfaces ───────────────────────── */
+    --bg-base: #ffffff;
+    --bg-surface: #f3f3f3;
+    --bg-elevated: #ffffff;
+    --bg-overlay: #ffffff;
+    --bg-inset: #f8f8f8;
+    --bg-widget: #f3f3f3;
+
+    /* ── Background: Interactive ─────────────────────────── */
+    --bg-interactive: #e8e8e8;
+    --bg-hover: #e4e4e4;
+    --bg-active: #d6d6d6;
+    --bg-selected: #cfe3ff;
+
+    /* ── Background: IDE regions ─────────────────────────── */
+    --bg-topbar: #f8f8f8;
+    --bg-tabbar: #ececec;
+    --bg-tab-active: #ffffff;
+    --bg-tab-inactive: #ececec;
+    --bg-sidebar: #f3f3f3;
+    --bg-canvas: #f8f8f8;
+    --bg-preview: #ffffff;
+    --bg-utilitybar: #f3f3f3;
+    --bg-statusbar: #0078d4;
+    --bg-footer: #f3f3f3;
+
+    /* ── Background: Inputs & overlays ───────────────────── */
+    --bg-input: #ffffff;
+    --bg-input-hover: #f0f0f0;
+    --bg-scrim: rgba(0, 0, 0, 0.3);
+    --bg-tooltip: #ffffff;
+    --bg-dropdown: #ffffff;
+
+    /* ── Text: Hierarchy ─────────────────────────────────── */
+    --text-primary: #1f1f1f;
+    --text-secondary: #3b3b3b;
+    --text-muted: #6e6e6e;
+    --text-disabled: #a6a6a6;
+    --text-placeholder: #8a8a8a;
+    --text-inverse: #ffffff;
+    --text-on-accent: #ffffff;
+    --text-on-node: #333333;
+
+    /* ── Text: Links ─────────────────────────────────────── */
+    --text-link: #006ab1;
+    --text-link-hover: #0078d4;
+
+    /* ── Text: IDE regions ───────────────────────────────── */
+    --text-tab-active: #1f1f1f;
+    --text-tab-inactive: #6e6e6e;
+    --text-sidebar: #3b3b3b;
+    --text-sidebar-heading: #1f1f1f;
+    --text-statusbar: #ffffff;
+
+    /* ── Accent & semantic — keep hues; darken the pastel
+         "-text" variants that were tuned for a dark surface ─ */
+    --color-accent-muted: rgba(0, 120, 212, 0.12);
+    --color-success-text: #2e7d32;
+    --color-danger-text: #c0392b;
+
+    /* ── Borders — black alphas instead of white ─────────── */
+    --border-subtle: rgba(0, 0, 0, 0.08);
+    --border-default: rgba(0, 0, 0, 0.12);
+    --border-medium: rgba(0, 0, 0, 0.18);
+    --border-strong: rgba(0, 0, 0, 0.28);
+    --border-input: rgba(0, 0, 0, 0.15);
+    --border-input-hover: rgba(0, 0, 0, 0.3);
+    --border-panel: rgba(0, 0, 0, 0.1);
+    --border-resize: rgba(0, 0, 0, 0.08);
+
+    /* ── Shadows — softer on a light surface ─────────────── */
+    --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
+    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.12);
+    --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.18);
+    --shadow-modal: 0 3px 10px rgba(0, 0, 0, 0.15);
+    --shadow-dropdown: 0 4px 16px rgba(0, 0, 0, 0.15);
+    --shadow-inset-sm: inset 0 1px 3px rgba(0, 0, 0, 0.08);
+
+    /* ── Scrollbar ───────────────────────────────────────── */
+    --scrollbar-thumb: rgba(0, 0, 0, 0.2);
+    --scrollbar-thumb-hover: rgba(0, 0, 0, 0.35);
+
+    /* ── Minimap ─────────────────────────────────────────── */
+    --minimap-bg: #ececec;
+    --minimap-mask: rgba(0, 0, 0, 0.1);
+}
+
+/* Bootstrap's .btn-close ships a black icon — correct on a light modal, so
+   undo the dark-theme invert filter below when in light mode. */
+:root[data-theme='light'] .modal-content .btn-close {
+    filter: none;
+}
+
 /* ============================================
    Dark-theme overrides for Bootstrap modal close button.
    Bootstrap renders .btn-close with a hardcoded black SVG icon; we filter to

--- a/src/styles/topBar.css
+++ b/src/styles/topBar.css
@@ -81,6 +81,21 @@
     box-shadow: none;
 }
 
+/* Icon-only theme toggle — square hit target, centered glyph. Sits at the
+   leading edge of the right-side action cluster. */
+.top-bar-theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px;
+    margin-right: 2px;
+    color: var(--text-muted);
+}
+
+.top-bar-theme-toggle:hover {
+    color: var(--text-primary);
+}
+
 /* External-link anchors (Docs / GitHub / Issues) — strip every hover affordance
    except the text getting brighter (--text-muted → --text-primary, inherited
    from .top-bar-btn:hover above). No gray fill, no scale, no shadow. */


### PR DESCRIPTION
## Summary

Adds a light theme and a top-bar toggle. All colors are already CSS variables,
so this is a `data-theme="light"` override plus a pre-paint init and a toggle
button — no per-component changes.

## Demo

**Before**

<!-- drag before.mp4 here -->

**After**

<!-- drag after.mp4 here -->

## Changes

- `src/styles/tokens.css` — light-theme variable overrides.
- `index.html` — resolve the theme before first paint (saved choice, else OS preference).
- `src/components/ThemeToggle.jsx` — toggle button.
- `src/components/TopBar.jsx` — render the toggle.
- `src/styles/topBar.css` — toggle styling.

## Testing

- [ ] The toggle flips the whole UI; no element stays dark.
- [ ] The choice persists on reload; a first visit follows the OS setting.
- [ ] Light-mode contrast holds for text, borders, accent, and selected states.
