### PR TITLE
feat: add canvas undo/redo for structural operations

### DIFF
--- a/src/components/workflowCanvas.jsx
+++ b/src/components/workflowCanvas.jsx
@@ -9,6 +9,7 @@ import EdgeMappingModal from './EdgeMappingModal';
 import { useNodeLookup } from '../hooks/useNodeLookup.js';
 import { useBIDSHandler } from '../hooks/useBIDSHandler.js';
 import { useCanvasShortcuts } from '../hooks/useCanvasShortcuts.js';
+import { useCanvasHistory } from '../hooks/useCanvasHistory.js';
 import { useCanvasClipboard } from '../hooks/useCanvasClipboard.js';
 import { useFlowContexts } from '../hooks/useFlowContexts.js';
 import { useEdgeMapping } from '../hooks/useEdgeMapping.js';
@@ -59,6 +60,19 @@ function WorkflowCanvas({
         needsSyncRef.current = true;
     }, []);
 
+    // Undo/redo for canvas structure. record() fires at the same chokepoint that
+    // persists to the workspace, so programmatic loads (which don't markForSync)
+    // are never recorded; reset() re-baselines on workspace load. onRestore
+    // re-persists the restored snapshot.
+    const {
+        record: recordHistory,
+        reset: resetHistory,
+        undo: undoHistory,
+        redo: redoHistory,
+        canUndo,
+        canRedo,
+    } = useCanvasHistory({ setNodes, setEdges, onRestore: markForSync });
+
     useEffect(() => {
         if (needsSyncRef.current) {
             needsSyncRef.current = false;
@@ -66,6 +80,7 @@ function WorkflowCanvas({
                 const viewport = reactFlowInstance?.getViewport() || null;
                 updateCurrentWorkspaceItems({ nodes, edges, viewport });
             }
+            recordHistory(nodes, edges);
         }
         // Reason: reactFlowInstance is read at fire time only; we don't want to re-sync just because ReactFlow rebound the instance ref.
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -253,6 +268,9 @@ function WorkflowCanvas({
                 }));
                 setNodes(initialNodes);
                 setEdges(initialEdges);
+                // Re-baseline undo/redo to the freshly loaded content so history
+                // never carries over between workspaces (or across a reload).
+                resetHistory(initialNodes, initialEdges);
 
                 // Auto-center on all nodes when switching workspaces
                 if (workspaceSwitched && reactFlowInstance) {
@@ -599,10 +617,22 @@ function WorkflowCanvas({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [clipboard, setNodes, setEdges, markForSync]);
 
+    // A node drag updates positions through ReactFlow's onNodesChange without
+    // marking sync; on drag stop we record the settled positions as one history
+    // entry (ReactFlow already coalesces the drag into a single stop) and mark
+    // for persistence. record() is signature-gated, so the later sync flush
+    // won't double-count it.
+    const handleNodeDragStop = useCallback(() => {
+        recordHistory(nodes, edges);
+        markForSync();
+    }, [nodes, edges, recordHistory, markForSync]);
+
     useCanvasShortcuts({
         onAutoLayout: handleAutoLayout,
         onCopy: handleCopy,
         onPaste: handlePaste,
+        onUndo: undoHistory,
+        onRedo: redoHistory,
     });
 
     // Provide complete workflow data for exporting.
@@ -652,6 +682,7 @@ function WorkflowCanvas({
                                 onEdgesChange={handleEdgesChange}
                                 onConnect={onConnect}
                                 onNodesDelete={onNodesDelete}
+                                onNodeDragStop={handleNodeDragStop}
                                 onSelectionChange={onSelectionChange}
                                 onEdgeDoubleClick={onEdgeDoubleClick}
                                 nodeTypes={nodeTypes}
@@ -680,6 +711,22 @@ function WorkflowCanvas({
                                         onClick={() => setToolsHidden((prev) => !prev)}
                                     >
                                         {toolsHidden ? 'Show tools' : 'Hide tools'}
+                                    </button>
+                                    <button
+                                        className="canvas-bottom-btn collapsible"
+                                        onClick={undoHistory}
+                                        disabled={!canUndo}
+                                        title="Undo (Ctrl/Cmd+Z)"
+                                    >
+                                        Undo
+                                    </button>
+                                    <button
+                                        className="canvas-bottom-btn collapsible"
+                                        onClick={redoHistory}
+                                        disabled={!canRedo}
+                                        title="Redo (Ctrl/Cmd+Shift+Z)"
+                                    >
+                                        Redo
                                     </button>
                                     <button
                                         className="canvas-bottom-btn collapsible"

--- a/src/hooks/useCanvasHistory.js
+++ b/src/hooks/useCanvasHistory.js
@@ -1,0 +1,111 @@
+import { useCallback, useRef, useState } from 'react';
+
+/**
+ * Structural signature of a canvas — the parts that undo/redo cares about:
+ * node identity + position, and edge identity + wiring + mappings. Deliberately
+ * EXCLUDES node.data (parameters), selection, and drag flags, so a parameter
+ * edit or a selection change does not register as an undoable step.
+ */
+function structuralSig(nodes, edges) {
+    const n = (nodes || [])
+        .map((nd) => `${nd.id}@${Math.round(nd.position?.x ?? 0)},${Math.round(nd.position?.y ?? 0)}`)
+        .join(';');
+    const e = (edges || [])
+        .map(
+            (ed) =>
+                `${ed.id}:${ed.source}>${ed.target}:${ed.sourceHandle ?? ''}>${ed.targetHandle ?? ''}:${JSON.stringify(
+                    ed.data?.mappings ?? [],
+                )}`,
+        )
+        .join(';');
+    return `${n}||${e}`;
+}
+
+/**
+ * Undo/redo for canvas STRUCTURE — adding/removing nodes and edges, moving
+ * nodes, and rewiring edge mappings. Parameter edits are intentionally not
+ * undoable (see structuralSig).
+ *
+ * The model is the classic past / present / future triple over `{nodes, edges}`
+ * snapshots:
+ *   - `record(nodes, edges)` is the commit point. Call it whenever the canvas
+ *     settles after a meaningful change (in this app, the same place that
+ *     persists to the workspace). If the structure changed it pushes the prior
+ *     snapshot onto the undo stack and clears redo; if only parameters changed
+ *     it just refreshes the present snapshot so a later undo keeps live params.
+ *   - `reset(nodes, edges)` re-baselines and clears both stacks — call it when a
+ *     workspace loads, so history never bleeds across workspaces.
+ *   - `undo` / `redo` restore a snapshot and invoke `onRestore` (used here to
+ *     re-persist the restored state). The restore is idempotent: the resulting
+ *     `record` sees an unchanged signature and adds no entry.
+ *
+ * Snapshots are bounded (`limit`, default 50) so memory stays flat.
+ */
+export function useCanvasHistory({ setNodes, setEdges, onRestore, limit = 50 }) {
+    const present = useRef({ nodes: [], edges: [], sig: structuralSig([], []) });
+    const past = useRef([]);
+    const future = useRef([]);
+    // Bump to re-render consumers (toolbar buttons) when canUndo/canRedo flip.
+    const [, force] = useState(0);
+    const bump = useCallback(() => force((v) => v + 1), []);
+
+    const reset = useCallback(
+        (nodes, edges) => {
+            present.current = { nodes, edges, sig: structuralSig(nodes, edges) };
+            past.current = [];
+            future.current = [];
+            bump();
+        },
+        [bump],
+    );
+
+    const record = useCallback(
+        (nodes, edges) => {
+            const sig = structuralSig(nodes, edges);
+            if (sig === present.current.sig) {
+                // Non-structural change (e.g. a parameter edit): keep the latest
+                // content so a future undo restores up-to-date params, but don't
+                // add a history entry.
+                present.current = { nodes, edges, sig };
+                return;
+            }
+            past.current.push(present.current);
+            if (past.current.length > limit) past.current.shift();
+            future.current = [];
+            present.current = { nodes, edges, sig };
+            bump();
+        },
+        [bump, limit],
+    );
+
+    const undo = useCallback(() => {
+        if (past.current.length === 0) return;
+        const prev = past.current.pop();
+        future.current.push(present.current);
+        present.current = prev;
+        setNodes(prev.nodes);
+        setEdges(prev.edges);
+        onRestore?.();
+        bump();
+    }, [setNodes, setEdges, onRestore, bump]);
+
+    const redo = useCallback(() => {
+        if (future.current.length === 0) return;
+        const next = future.current.pop();
+        past.current.push(present.current);
+        present.current = next;
+        setNodes(next.nodes);
+        setEdges(next.edges);
+        onRestore?.();
+        bump();
+    }, [setNodes, setEdges, onRestore, bump]);
+
+    return {
+        record,
+        reset,
+        undo,
+        redo,
+        canUndo: past.current.length > 0,
+        canRedo: future.current.length > 0,
+    };
+}

--- a/src/hooks/useCanvasShortcuts.js
+++ b/src/hooks/useCanvasShortcuts.js
@@ -4,9 +4,14 @@ import { useEffect } from 'react';
  * Canvas-scoped keyboard shortcuts.
  *
  * Bindings:
- *   Ctrl+Shift+L → auto-layout
- *   Ctrl+C       → copy current selection (skipped when focus is inside an input/textarea)
- *   Ctrl+V       → paste (skipped when focus is inside an input/textarea)
+ *   Ctrl+Shift+L      → auto-layout
+ *   Ctrl+C            → copy current selection (skipped when focus is inside an input/textarea)
+ *   Ctrl+V            → paste (skipped when focus is inside an input/textarea)
+ *   Ctrl/Cmd+Z        → undo canvas structural change (skipped inside an input/textarea)
+ *   Ctrl/Cmd+Shift+Z  → redo (Ctrl+Y also works)
+ *
+ * Undo/redo accept Cmd on macOS as well as Ctrl, since Cmd+Z is the platform
+ * norm; the other bindings keep the app's existing Ctrl-only convention.
  *
  * Ctrl+S is handled globally in main.jsx so it works from the sidebar and aux
  * tabs too — don't add it here (would double-fire).
@@ -18,16 +23,34 @@ import { useEffect } from 'react';
  * @param {() => void} handlers.onAutoLayout
  * @param {() => void} [handlers.onCopy]
  * @param {() => void} [handlers.onPaste]
+ * @param {() => void} [handlers.onUndo]
+ * @param {() => void} [handlers.onRedo]
  */
-export function useCanvasShortcuts({ onAutoLayout, onCopy, onPaste }) {
+export function useCanvasShortcuts({ onAutoLayout, onCopy, onPaste, onUndo, onRedo }) {
     useEffect(() => {
         const isEditableTarget = (target) =>
             target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
 
         const handleKeyDown = (e) => {
+            const mod = e.ctrlKey || e.metaKey;
+            const isZ = e.key === 'z' || e.key === 'Z';
+            const isY = e.key === 'y' || e.key === 'Y';
+
             if (e.ctrlKey && e.shiftKey && (e.key === 'L' || e.key === 'l')) {
                 e.preventDefault();
                 onAutoLayout?.();
+            } else if (mod && e.shiftKey && isZ) {
+                if (isEditableTarget(e.target)) return;
+                e.preventDefault();
+                onRedo?.();
+            } else if (mod && !e.shiftKey && isZ) {
+                if (isEditableTarget(e.target)) return;
+                e.preventDefault();
+                onUndo?.();
+            } else if (e.ctrlKey && !e.shiftKey && isY) {
+                if (isEditableTarget(e.target)) return;
+                e.preventDefault();
+                onRedo?.();
             } else if (e.ctrlKey && !e.shiftKey && (e.key === 'c' || e.key === 'C')) {
                 if (isEditableTarget(e.target)) return;
                 e.preventDefault();
@@ -41,5 +64,5 @@ export function useCanvasShortcuts({ onAutoLayout, onCopy, onPaste }) {
 
         window.addEventListener('keydown', handleKeyDown);
         return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [onAutoLayout, onCopy, onPaste]);
+    }, [onAutoLayout, onCopy, onPaste, onUndo, onRedo]);
 }


### PR DESCRIPTION
## Summary

Adds undo/redo for canvas structure — adding and removing nodes and edges,
moving nodes, and rewiring edges. Parameter edits are intentionally excluded.
Bound to Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z, with toolbar buttons.

## Demo

**Before**

<!-- drag before.mp4 here -->

**After**

<!-- drag after.mp4 here -->

## Changes

- `src/hooks/useCanvasHistory.js` — bounded snapshot history, signature-gated commits, per-workspace reset.
- `src/hooks/useCanvasShortcuts.js` — undo/redo key bindings.
- `src/components/workflowCanvas.jsx` — record at the persistence point, reset on workspace load, capture moves on drag-stop, and add the toolbar buttons.

## Testing

- [ ] Add a node → undo removes it → redo restores it.
- [ ] Delete a node that has edges → undo restores the node and its edges.
- [ ] A drag is a single undo step; a parameter edit creates no history entry.
- [ ] Switching workspaces does not carry history across.
